### PR TITLE
Don't use `module.exports =`

### DIFF
--- a/ts-serverless-gateway/src/index.ts
+++ b/ts-serverless-gateway/src/index.ts
@@ -1,11 +1,9 @@
 import * as express from 'express';
-import uuidAPI = require('uuid');
-const uuid = uuidAPI.v4
 const { router, app } = setupExpressApp();
 
-const quotes = require('./quotes/quotes');
-const userGet = require('./users/get-users');
-const userPost = require('./users/post-users');
+import * as quotes from './quotes/quotes';
+import * as userGet from './users/get-users';
+import * as userPost from './users/post-users';
 
 router.get('/', async (req, res) => {
   res.send("Hello from Klotho!");
@@ -30,8 +28,8 @@ app.listen(3000, async () => {
 })
 
 app.use(router)
-app.use(quotes)
-app.use(userGet)
-app.use(userPost)
+app.use(quotes.router)
+app.use(userGet.router)
+app.use(userPost.router)
 
 exports.app = app

--- a/ts-serverless-gateway/src/quotes/quotes.ts
+++ b/ts-serverless-gateway/src/quotes/quotes.ts
@@ -7,7 +7,7 @@
  * }
  */
 
- const quotes = require('express').Router();
+export const router = require('express').Router();
 
 
 /**
@@ -42,7 +42,5 @@ async function getQuote(req, res) {
 }
 
 
-quotes.post('/v1/quote', postQuote);
-quotes.get('/v1/quote-list', getQuote);
-
-module.exports = quotes;
+router.post('/v1/quote', postQuote);
+router.get('/v1/quote-list', getQuote);

--- a/ts-serverless-gateway/src/users/get-users.ts
+++ b/ts-serverless-gateway/src/users/get-users.ts
@@ -8,14 +8,11 @@
  */
 
 
-const userGet = require('express').Router();
+export const router = require('express').Router();
 
 function getUsers(event, res) {
     let usersList = "[user1, user2, user3]"
     res.send(usersList);
 }
 
-userGet.get('/v1/users', getUsers);
-
-module.exports = userGet;
- 
+router.get('/v1/users', getUsers);

--- a/ts-serverless-gateway/src/users/post-users.ts
+++ b/ts-serverless-gateway/src/users/post-users.ts
@@ -8,12 +8,11 @@
  */
 
 
-const userPost = require('express').Router();
+export const router = require('express').Router();
 
 function postUsers(event, res) {
     let resp = `Hi ${event.body.user}`;
     res.send();
 }
 
-userPost.post('/v1/users', postUsers);
-module.exports = userPost;
+router.post('/v1/users', postUsers);


### PR DESCRIPTION
This stomps the other exports and could lead to problems down the road in other contexts,
so don't do it in sample-apps which people may copy from.

Here's the relevant part of the compiled pulumi `index.ts` (to show it still parses correctly):

```ts
gateways.push(cloudLib.createDockerBasedAPIGateway(
    execUnits,
    [{"execUnitName":"srvless-quotes","path":"/","verb":"get"},{"execUnitName":"srvless-quotes","path":"/v1/quote","verb":"post"},{"execUnitName":"srvless-quotes","path":"/v1/quote-list","verb":"get"},{"execUnitName":"srvless-userget","path":"/v1/users","verb":"get"},{"execUnitName":"srvless-userpost","path":"/v1/users","verb":"post"}],
    "index.js#app",
));
```

And the compiler output:
![image](https://user-images.githubusercontent.com/90645437/182676038-8cedfe9e-ffc4-4186-beb4-fa782750511a.png)
