### PR TITLE
install typescript as dev-dep in all examples

### DIFF
--- a/ts-cloudfs/package-lock.json
+++ b/ts-cloudfs/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "@types/express": "^4.17.13",
-        "@types/node": "^17.0.4"
+        "@types/node": "^17.0.4",
+        "typescript": "^4.8.3"
       }
     },
     "node_modules/@types/body-parser": {
@@ -560,6 +561,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1012,6 +1026,12 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typescript": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",

--- a/ts-cloudfs/package.json
+++ b/ts-cloudfs/package.json
@@ -11,7 +11,8 @@
   "license": "ISC",
   "devDependencies": {
     "@types/express": "^4.17.13",
-    "@types/node": "^17.0.4"
+    "@types/node": "^17.0.4",
+    "typescript": "^4.8.3"
   },
   "dependencies": {
     "express": "^4.17.2"

--- a/ts-events/package-lock.json
+++ b/ts-events/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "express": "^4.18.1",
-        "typescript": "^4.6.4"
+        "express": "^4.18.1"
       },
       "devDependencies": {
         "@types/node": "^17.0.34",
-        "ts-node": "^10.7.0"
+        "ts-node": "^10.7.0",
+        "typescript": "^4.8.3"
       }
     },
     "node_modules/@cspotcode/source-map-consumer": {
@@ -712,9 +712,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1276,9 +1277,10 @@
       }
     },
     "typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg=="
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",

--- a/ts-events/package.json
+++ b/ts-events/package.json
@@ -9,11 +9,11 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.18.1",
-    "typescript": "^4.6.4"
+    "express": "^4.18.1"
   },
   "devDependencies": {
     "@types/node": "^17.0.34",
-    "ts-node": "^10.7.0"
+    "ts-node": "^10.7.0",
+    "typescript": "^4.8.3"
   }
 }

--- a/ts-graphql/package-lock.json
+++ b/ts-graphql/package-lock.json
@@ -17,7 +17,8 @@
       },
       "devDependencies": {
         "@types/express": "^4.17.13",
-        "@types/node": "^16.11.6"
+        "@types/node": "^16.11.6",
+        "typescript": "^4.8.3"
       }
     },
     "node_modules/@apollo/protobufjs": {
@@ -1950,6 +1951,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -3632,6 +3646,12 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typescript": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/ts-graphql/package.json
+++ b/ts-graphql/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.13",
-    "@types/node": "^16.11.6"
+    "@types/node": "^16.11.6",
+    "typescript": "^4.8.3"
   }
 }

--- a/ts-media-storage/package-lock.json
+++ b/ts-media-storage/package-lock.json
@@ -16,7 +16,7 @@
       "devDependencies": {
         "@types/node": "^17.0.10",
         "ts-node": "^10.4.0",
-        "typescript": "^4.5.4"
+        "typescript": "^4.8.3"
       }
     },
     "node_modules/@cspotcode/source-map-consumer": {
@@ -806,9 +806,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -1475,9 +1475,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "dev": true
     },
     "unpipe": {

--- a/ts-media-storage/package.json
+++ b/ts-media-storage/package.json
@@ -10,6 +10,6 @@
   "devDependencies": {
     "@types/node": "^17.0.10",
     "ts-node": "^10.4.0",
-    "typescript": "^4.5.4"
+    "typescript": "^4.8.3"
   }
 }

--- a/ts-microservices/package-lock.json
+++ b/ts-microservices/package-lock.json
@@ -12,7 +12,8 @@
         "express": "^4.17.2"
       },
       "devDependencies": {
-        "@types/express": "^4.17.13"
+        "@types/express": "^4.17.13",
+        "typescript": "^4.8.3"
       }
     },
     "node_modules/@types/body-parser": {
@@ -559,6 +560,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1011,6 +1025,12 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typescript": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",

--- a/ts-microservices/package.json
+++ b/ts-microservices/package.json
@@ -13,6 +13,7 @@
     "express": "^4.17.2"
   },
   "devDependencies": {
-    "@types/express": "^4.17.13"
+    "@types/express": "^4.17.13",
+    "typescript": "^4.8.3"
   }
 }

--- a/ts-orm/package-lock.json
+++ b/ts-orm/package-lock.json
@@ -20,7 +20,8 @@
       "devDependencies": {
         "@types/express": "^4.17.13",
         "@types/node": "^17.0.4",
-        "@types/sequelize": "^4.28.13"
+        "@types/sequelize": "^4.28.13",
+        "typescript": "^4.8.3"
       }
     },
     "node_modules/@gar/promisify": {
@@ -2426,6 +2427,19 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/typescript": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/underscore": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
@@ -4383,6 +4397,12 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
+    },
+    "typescript": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true
     },
     "underscore": {
       "version": "1.13.4",

--- a/ts-orm/package.json
+++ b/ts-orm/package.json
@@ -12,7 +12,8 @@
   "devDependencies": {
     "@types/express": "^4.17.13",
     "@types/node": "^17.0.4",
-    "@types/sequelize": "^4.28.13"
+    "@types/sequelize": "^4.28.13",
+    "typescript": "^4.8.3"
   },
   "dependencies": {
     "express": "^4.17.2",

--- a/ts-redis/package-lock.json
+++ b/ts-redis/package-lock.json
@@ -14,7 +14,8 @@
       },
       "devDependencies": {
         "@types/express": "^4.17.13",
-        "@types/node": "^17.0.4"
+        "@types/node": "^17.0.4",
+        "typescript": "^4.8.3"
       }
     },
     "node_modules/@redis/bloom": {
@@ -727,6 +728,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1305,6 +1319,12 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typescript": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",

--- a/ts-redis/package.json
+++ b/ts-redis/package.json
@@ -11,7 +11,8 @@
   "license": "ISC",
   "devDependencies": {
     "@types/express": "^4.17.13",
-    "@types/node": "^17.0.4"
+    "@types/node": "^17.0.4",
+    "typescript": "^4.8.3"
   },
   "dependencies": {
     "express": "^4.17.2",

--- a/ts-schedule/package-lock.json
+++ b/ts-schedule/package-lock.json
@@ -14,7 +14,8 @@
       },
       "devDependencies": {
         "@types/express": "^4.17.13",
-        "@types/node": "^17.0.4"
+        "@types/node": "^17.0.4",
+        "typescript": "^4.8.3"
       }
     },
     "node_modules/@types/body-parser": {
@@ -577,6 +578,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1042,6 +1056,12 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typescript": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",

--- a/ts-schedule/package.json
+++ b/ts-schedule/package.json
@@ -11,10 +11,11 @@
   "license": "ISC",
   "devDependencies": {
     "@types/express": "^4.17.13",
-    "@types/node": "^17.0.4"
+    "@types/node": "^17.0.4",
+    "typescript": "^4.8.3"
   },
   "dependencies": {
     "express": "^4.17.2",
-    "lambda-log":"^3.0.0"
+    "lambda-log": "^3.0.0"
   }
 }

--- a/ts-secrets/package-lock.json
+++ b/ts-secrets/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "@types/express": "^4.17.13",
-        "@types/node": "^17.0.4"
+        "@types/node": "^17.0.4",
+        "typescript": "^4.8.3"
       }
     },
     "node_modules/@types/body-parser": {
@@ -560,6 +561,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1012,6 +1026,12 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typescript": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",

--- a/ts-secrets/package.json
+++ b/ts-secrets/package.json
@@ -11,7 +11,8 @@
   "license": "ISC",
   "devDependencies": {
     "@types/express": "^4.17.13",
-    "@types/node": "^17.0.4"
+    "@types/node": "^17.0.4",
+    "typescript": "^4.8.3"
   },
   "dependencies": {
     "express": "^4.17.2"

--- a/ts-serverless-gateway/package-lock.json
+++ b/ts-serverless-gateway/package-lock.json
@@ -14,7 +14,7 @@
         "@types/got": "^9.6.11",
         "@types/node": "^14.14.37",
         "ts-node": "^10.2.1",
-        "typescript": "^4.4.3"
+        "typescript": "^4.8.3"
       }
     },
     "node_modules/@cspotcode/source-map-consumer": {
@@ -958,9 +958,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -1741,9 +1741,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
-      "integrity": "sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "dev": true
     },
     "unpipe": {

--- a/ts-serverless-gateway/package.json
+++ b/ts-serverless-gateway/package.json
@@ -9,6 +9,6 @@
     "@types/got": "^9.6.11",
     "@types/node": "^14.14.37",
     "ts-node": "^10.2.1",
-    "typescript": "^4.4.3"
+    "typescript": "^4.8.3"
   }
 }


### PR DESCRIPTION
Done mechanically via:

```
$ for d in ts-* ; do (cd $d && npm install typescript --save-dev); done
```

Verified via:

```
$ git clean -fdx  # remove anything that's not tracked in git

$ for d in ts-* ; do (cd $d && npm ci && npx tsc); done
```