### PR TITLE
add `npm run <klotho | pulumi>` scripts

### DIFF
--- a/ts-cloudfs/package.json
+++ b/ts-cloudfs/package.json
@@ -4,6 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "klotho": "scripts/klotho/npm/klotho",
+    "pulumi": "scripts/klotho/npm/pulumi",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/ts-cloudfs/scripts/klotho/npm/_common.sh
+++ b/ts-cloudfs/scripts/klotho/npm/_common.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")" # cd to where we are now
+cd ../../.. # get to repo root
+
+# Default the app name to the package name. If we have jq available on PATH, prefer that to "npm pkg" — it's
+# significantly faster.
+if &>/dev/null jq --version ;  then
+  default_app_name="$(cat package.json | jq -r .name)"
+else
+  default_app_name="$(npm pkg get name | sed -E 's/^"|"$//g')"
+fi
+if [[ -z "${KLOTHO_APP_NAME:-}" ]]; then
+  export KLOTHO_APP_NAME="$default_app_name"
+fi
+
+if [[ "$KLOTHO_APP_NAME" == "$default_app_name" ]]; then
+  KLOTHO_OUT_DIR=compiled
+else
+  KLOTHO_OUT_DIR="compiled-klotho/$KLOTHO_APP_NAME"
+fi
+export KLOTHO_OUT_DIR

--- a/ts-cloudfs/scripts/klotho/npm/klotho
+++ b/ts-cloudfs/scripts/klotho/npm/klotho
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ ! -d node_modules ]]; then
+  npm ci
+fi
+npx tsc
+strict_mode=''
+if [[ -n "${KLOTHO_STRICT-}" ]]; then
+  strict_mode='--strict'
+fi
+klotho . $strict_mode --app "$KLOTHO_APP_NAME" --outDir "$KLOTHO_OUT_DIR"
+npm --prefix "$KLOTHO_OUT_DIR" install

--- a/ts-cloudfs/scripts/klotho/npm/pulumi
+++ b/ts-cloudfs/scripts/klotho/npm/pulumi
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ -z "${PULUMI_CONFIG_PASSPHRASE+x}" && -z "${PULUMI_CONFIG_PASSPHRASE_FILE+x}" ]]; then
+  export PULUMI_CONFIG_PASSPHRASE=''
+fi
+
+pulumi -C "$KLOTHO_OUT_DIR" --stack "$KLOTHO_APP_NAME" "$@"

--- a/ts-embed_assets/package.json
+++ b/ts-embed_assets/package.json
@@ -4,6 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "klotho": "scripts/klotho/npm/klotho",
+    "pulumi": "scripts/klotho/npm/pulumi",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/ts-embed_assets/scripts/klotho/npm/_common.sh
+++ b/ts-embed_assets/scripts/klotho/npm/_common.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")" # cd to where we are now
+cd ../../.. # get to repo root
+
+# Default the app name to the package name. If we have jq available on PATH, prefer that to "npm pkg" — it's
+# significantly faster.
+if &>/dev/null jq --version ;  then
+  default_app_name="$(cat package.json | jq -r .name)"
+else
+  default_app_name="$(npm pkg get name | sed -E 's/^"|"$//g')"
+fi
+if [[ -z "${KLOTHO_APP_NAME:-}" ]]; then
+  export KLOTHO_APP_NAME="$default_app_name"
+fi
+
+if [[ "$KLOTHO_APP_NAME" == "$default_app_name" ]]; then
+  KLOTHO_OUT_DIR=compiled
+else
+  KLOTHO_OUT_DIR="compiled-klotho/$KLOTHO_APP_NAME"
+fi
+export KLOTHO_OUT_DIR

--- a/ts-embed_assets/scripts/klotho/npm/klotho
+++ b/ts-embed_assets/scripts/klotho/npm/klotho
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ ! -d node_modules ]]; then
+  npm ci
+fi
+npx tsc
+strict_mode=''
+if [[ -n "${KLOTHO_STRICT-}" ]]; then
+  strict_mode='--strict'
+fi
+klotho . $strict_mode --app "$KLOTHO_APP_NAME" --outDir "$KLOTHO_OUT_DIR"
+npm --prefix "$KLOTHO_OUT_DIR" install

--- a/ts-embed_assets/scripts/klotho/npm/pulumi
+++ b/ts-embed_assets/scripts/klotho/npm/pulumi
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ -z "${PULUMI_CONFIG_PASSPHRASE+x}" && -z "${PULUMI_CONFIG_PASSPHRASE_FILE+x}" ]]; then
+  export PULUMI_CONFIG_PASSPHRASE=''
+fi
+
+pulumi -C "$KLOTHO_OUT_DIR" --stack "$KLOTHO_APP_NAME" "$@"

--- a/ts-events/package.json
+++ b/ts-events/package.json
@@ -4,6 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "klotho": "scripts/klotho/npm/klotho",
+    "pulumi": "scripts/klotho/npm/pulumi",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/ts-events/scripts/klotho/npm/_common.sh
+++ b/ts-events/scripts/klotho/npm/_common.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")" # cd to where we are now
+cd ../../.. # get to repo root
+
+# Default the app name to the package name. If we have jq available on PATH, prefer that to "npm pkg" — it's
+# significantly faster.
+if &>/dev/null jq --version ;  then
+  default_app_name="$(cat package.json | jq -r .name)"
+else
+  default_app_name="$(npm pkg get name | sed -E 's/^"|"$//g')"
+fi
+if [[ -z "${KLOTHO_APP_NAME:-}" ]]; then
+  export KLOTHO_APP_NAME="$default_app_name"
+fi
+
+if [[ "$KLOTHO_APP_NAME" == "$default_app_name" ]]; then
+  KLOTHO_OUT_DIR=compiled
+else
+  KLOTHO_OUT_DIR="compiled-klotho/$KLOTHO_APP_NAME"
+fi
+export KLOTHO_OUT_DIR

--- a/ts-events/scripts/klotho/npm/klotho
+++ b/ts-events/scripts/klotho/npm/klotho
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ ! -d node_modules ]]; then
+  npm ci
+fi
+npx tsc
+strict_mode=''
+if [[ -n "${KLOTHO_STRICT-}" ]]; then
+  strict_mode='--strict'
+fi
+klotho . $strict_mode --app "$KLOTHO_APP_NAME" --outDir "$KLOTHO_OUT_DIR"
+npm --prefix "$KLOTHO_OUT_DIR" install

--- a/ts-events/scripts/klotho/npm/pulumi
+++ b/ts-events/scripts/klotho/npm/pulumi
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ -z "${PULUMI_CONFIG_PASSPHRASE+x}" && -z "${PULUMI_CONFIG_PASSPHRASE_FILE+x}" ]]; then
+  export PULUMI_CONFIG_PASSPHRASE=''
+fi
+
+pulumi -C "$KLOTHO_OUT_DIR" --stack "$KLOTHO_APP_NAME" "$@"

--- a/ts-graphql-yoga/package.json
+++ b/ts-graphql-yoga/package.json
@@ -4,6 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "klotho": "scripts/klotho/npm/klotho",
+    "pulumi": "scripts/klotho/npm/pulumi",
     "start": "tsc && node ./dist/index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/ts-graphql-yoga/scripts/klotho/npm/_common.sh
+++ b/ts-graphql-yoga/scripts/klotho/npm/_common.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")" # cd to where we are now
+cd ../../.. # get to repo root
+
+# Default the app name to the package name. If we have jq available on PATH, prefer that to "npm pkg" — it's
+# significantly faster.
+if &>/dev/null jq --version ;  then
+  default_app_name="$(cat package.json | jq -r .name)"
+else
+  default_app_name="$(npm pkg get name | sed -E 's/^"|"$//g')"
+fi
+if [[ -z "${KLOTHO_APP_NAME:-}" ]]; then
+  export KLOTHO_APP_NAME="$default_app_name"
+fi
+
+if [[ "$KLOTHO_APP_NAME" == "$default_app_name" ]]; then
+  KLOTHO_OUT_DIR=compiled
+else
+  KLOTHO_OUT_DIR="compiled-klotho/$KLOTHO_APP_NAME"
+fi
+export KLOTHO_OUT_DIR

--- a/ts-graphql-yoga/scripts/klotho/npm/klotho
+++ b/ts-graphql-yoga/scripts/klotho/npm/klotho
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ ! -d node_modules ]]; then
+  npm ci
+fi
+npx tsc
+strict_mode=''
+if [[ -n "${KLOTHO_STRICT-}" ]]; then
+  strict_mode='--strict'
+fi
+klotho . $strict_mode --app "$KLOTHO_APP_NAME" --outDir "$KLOTHO_OUT_DIR"
+npm --prefix "$KLOTHO_OUT_DIR" install

--- a/ts-graphql-yoga/scripts/klotho/npm/pulumi
+++ b/ts-graphql-yoga/scripts/klotho/npm/pulumi
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ -z "${PULUMI_CONFIG_PASSPHRASE+x}" && -z "${PULUMI_CONFIG_PASSPHRASE_FILE+x}" ]]; then
+  export PULUMI_CONFIG_PASSPHRASE=''
+fi
+
+pulumi -C "$KLOTHO_OUT_DIR" --stack "$KLOTHO_APP_NAME" "$@"

--- a/ts-graphql/package.json
+++ b/ts-graphql/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "description": "sample graphql app",
   "scripts": {
+    "klotho": "scripts/klotho/npm/klotho",
+    "pulumi": "scripts/klotho/npm/pulumi",
     "start": "ts-node src/index.ts"
   },
   "dependencies": {

--- a/ts-graphql/scripts/klotho/npm/_common.sh
+++ b/ts-graphql/scripts/klotho/npm/_common.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")" # cd to where we are now
+cd ../../.. # get to repo root
+
+# Default the app name to the package name. If we have jq available on PATH, prefer that to "npm pkg" — it's
+# significantly faster.
+if &>/dev/null jq --version ;  then
+  default_app_name="$(cat package.json | jq -r .name)"
+else
+  default_app_name="$(npm pkg get name | sed -E 's/^"|"$//g')"
+fi
+if [[ -z "${KLOTHO_APP_NAME:-}" ]]; then
+  export KLOTHO_APP_NAME="$default_app_name"
+fi
+
+if [[ "$KLOTHO_APP_NAME" == "$default_app_name" ]]; then
+  KLOTHO_OUT_DIR=compiled
+else
+  KLOTHO_OUT_DIR="compiled-klotho/$KLOTHO_APP_NAME"
+fi
+export KLOTHO_OUT_DIR

--- a/ts-graphql/scripts/klotho/npm/klotho
+++ b/ts-graphql/scripts/klotho/npm/klotho
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ ! -d node_modules ]]; then
+  npm ci
+fi
+npx tsc
+strict_mode=''
+if [[ -n "${KLOTHO_STRICT-}" ]]; then
+  strict_mode='--strict'
+fi
+klotho . $strict_mode --app "$KLOTHO_APP_NAME" --outDir "$KLOTHO_OUT_DIR"
+npm --prefix "$KLOTHO_OUT_DIR" install

--- a/ts-graphql/scripts/klotho/npm/pulumi
+++ b/ts-graphql/scripts/klotho/npm/pulumi
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ -z "${PULUMI_CONFIG_PASSPHRASE+x}" && -z "${PULUMI_CONFIG_PASSPHRASE_FILE+x}" ]]; then
+  export PULUMI_CONFIG_PASSPHRASE=''
+fi
+
+pulumi -C "$KLOTHO_OUT_DIR" --stack "$KLOTHO_APP_NAME" "$@"

--- a/ts-media-storage/package.json
+++ b/ts-media-storage/package.json
@@ -1,4 +1,8 @@
 {
+  "scripts": {
+    "klotho": "scripts/klotho/npm/klotho",
+    "pulumi": "scripts/klotho/npm/pulumi"
+  },
   "name": "starter-kit",
   "version": "1.0.0",
   "license": "MIT",

--- a/ts-media-storage/scripts/klotho/npm/_common.sh
+++ b/ts-media-storage/scripts/klotho/npm/_common.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")" # cd to where we are now
+cd ../../.. # get to repo root
+
+# Default the app name to the package name. If we have jq available on PATH, prefer that to "npm pkg" — it's
+# significantly faster.
+if &>/dev/null jq --version ;  then
+  default_app_name="$(cat package.json | jq -r .name)"
+else
+  default_app_name="$(npm pkg get name | sed -E 's/^"|"$//g')"
+fi
+if [[ -z "${KLOTHO_APP_NAME:-}" ]]; then
+  export KLOTHO_APP_NAME="$default_app_name"
+fi
+
+if [[ "$KLOTHO_APP_NAME" == "$default_app_name" ]]; then
+  KLOTHO_OUT_DIR=compiled
+else
+  KLOTHO_OUT_DIR="compiled-klotho/$KLOTHO_APP_NAME"
+fi
+export KLOTHO_OUT_DIR

--- a/ts-media-storage/scripts/klotho/npm/klotho
+++ b/ts-media-storage/scripts/klotho/npm/klotho
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ ! -d node_modules ]]; then
+  npm ci
+fi
+npx tsc
+strict_mode=''
+if [[ -n "${KLOTHO_STRICT-}" ]]; then
+  strict_mode='--strict'
+fi
+klotho . $strict_mode --app "$KLOTHO_APP_NAME" --outDir "$KLOTHO_OUT_DIR"
+npm --prefix "$KLOTHO_OUT_DIR" install

--- a/ts-media-storage/scripts/klotho/npm/pulumi
+++ b/ts-media-storage/scripts/klotho/npm/pulumi
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ -z "${PULUMI_CONFIG_PASSPHRASE+x}" && -z "${PULUMI_CONFIG_PASSPHRASE_FILE+x}" ]]; then
+  export PULUMI_CONFIG_PASSPHRASE=''
+fi
+
+pulumi -C "$KLOTHO_OUT_DIR" --stack "$KLOTHO_APP_NAME" "$@"

--- a/ts-microservices/package.json
+++ b/ts-microservices/package.json
@@ -4,6 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "klotho": "scripts/klotho/npm/klotho",
+    "pulumi": "scripts/klotho/npm/pulumi",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/ts-microservices/scripts/klotho/npm/_common.sh
+++ b/ts-microservices/scripts/klotho/npm/_common.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")" # cd to where we are now
+cd ../../.. # get to repo root
+
+# Default the app name to the package name. If we have jq available on PATH, prefer that to "npm pkg" — it's
+# significantly faster.
+if &>/dev/null jq --version ;  then
+  default_app_name="$(cat package.json | jq -r .name)"
+else
+  default_app_name="$(npm pkg get name | sed -E 's/^"|"$//g')"
+fi
+if [[ -z "${KLOTHO_APP_NAME:-}" ]]; then
+  export KLOTHO_APP_NAME="$default_app_name"
+fi
+
+if [[ "$KLOTHO_APP_NAME" == "$default_app_name" ]]; then
+  KLOTHO_OUT_DIR=compiled
+else
+  KLOTHO_OUT_DIR="compiled-klotho/$KLOTHO_APP_NAME"
+fi
+export KLOTHO_OUT_DIR

--- a/ts-microservices/scripts/klotho/npm/klotho
+++ b/ts-microservices/scripts/klotho/npm/klotho
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ ! -d node_modules ]]; then
+  npm ci
+fi
+npx tsc
+strict_mode=''
+if [[ -n "${KLOTHO_STRICT-}" ]]; then
+  strict_mode='--strict'
+fi
+klotho . $strict_mode --app "$KLOTHO_APP_NAME" --outDir "$KLOTHO_OUT_DIR"
+npm --prefix "$KLOTHO_OUT_DIR" install

--- a/ts-microservices/scripts/klotho/npm/pulumi
+++ b/ts-microservices/scripts/klotho/npm/pulumi
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ -z "${PULUMI_CONFIG_PASSPHRASE+x}" && -z "${PULUMI_CONFIG_PASSPHRASE_FILE+x}" ]]; then
+  export PULUMI_CONFIG_PASSPHRASE=''
+fi
+
+pulumi -C "$KLOTHO_OUT_DIR" --stack "$KLOTHO_APP_NAME" "$@"

--- a/ts-nestjs-sequelize/package.json
+++ b/ts-nestjs-sequelize/package.json
@@ -6,6 +6,8 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
+    "klotho": "scripts/klotho/npm/klotho",
+    "pulumi": "scripts/klotho/npm/pulumi",
     "prebuild": "rimraf dist",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",

--- a/ts-nestjs-sequelize/scripts/klotho/npm/_common.sh
+++ b/ts-nestjs-sequelize/scripts/klotho/npm/_common.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")" # cd to where we are now
+cd ../../.. # get to repo root
+
+# Default the app name to the package name. If we have jq available on PATH, prefer that to "npm pkg" — it's
+# significantly faster.
+if &>/dev/null jq --version ;  then
+  default_app_name="$(cat package.json | jq -r .name)"
+else
+  default_app_name="$(npm pkg get name | sed -E 's/^"|"$//g')"
+fi
+if [[ -z "${KLOTHO_APP_NAME:-}" ]]; then
+  export KLOTHO_APP_NAME="$default_app_name"
+fi
+
+if [[ "$KLOTHO_APP_NAME" == "$default_app_name" ]]; then
+  KLOTHO_OUT_DIR=compiled
+else
+  KLOTHO_OUT_DIR="compiled-klotho/$KLOTHO_APP_NAME"
+fi
+export KLOTHO_OUT_DIR

--- a/ts-nestjs-sequelize/scripts/klotho/npm/klotho
+++ b/ts-nestjs-sequelize/scripts/klotho/npm/klotho
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ ! -d node_modules ]]; then
+  npm ci
+fi
+npx tsc
+strict_mode=''
+if [[ -n "${KLOTHO_STRICT-}" ]]; then
+  strict_mode='--strict'
+fi
+klotho . $strict_mode --app "$KLOTHO_APP_NAME" --outDir "$KLOTHO_OUT_DIR"
+npm --prefix "$KLOTHO_OUT_DIR" install

--- a/ts-nestjs-sequelize/scripts/klotho/npm/pulumi
+++ b/ts-nestjs-sequelize/scripts/klotho/npm/pulumi
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ -z "${PULUMI_CONFIG_PASSPHRASE+x}" && -z "${PULUMI_CONFIG_PASSPHRASE_FILE+x}" ]]; then
+  export PULUMI_CONFIG_PASSPHRASE=''
+fi
+
+pulumi -C "$KLOTHO_OUT_DIR" --stack "$KLOTHO_APP_NAME" "$@"

--- a/ts-nextjs-typeorm/package.json
+++ b/ts-nextjs-typeorm/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "klotho": "scripts/klotho/npm/klotho",
+    "pulumi": "scripts/klotho/npm/pulumi",
     "dev": "npx tsc && node ./dist/server.js",
     "build": "npx tsc && next build",
     "start": "npx tsc && cross-env NODE_ENV=production node ./dist/server.js",

--- a/ts-nextjs-typeorm/scripts/klotho/npm/_common.sh
+++ b/ts-nextjs-typeorm/scripts/klotho/npm/_common.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")" # cd to where we are now
+cd ../../.. # get to repo root
+
+# Default the app name to the package name. If we have jq available on PATH, prefer that to "npm pkg" — it's
+# significantly faster.
+if &>/dev/null jq --version ;  then
+  default_app_name="$(cat package.json | jq -r .name)"
+else
+  default_app_name="$(npm pkg get name | sed -E 's/^"|"$//g')"
+fi
+if [[ -z "${KLOTHO_APP_NAME:-}" ]]; then
+  export KLOTHO_APP_NAME="$default_app_name"
+fi
+
+if [[ "$KLOTHO_APP_NAME" == "$default_app_name" ]]; then
+  KLOTHO_OUT_DIR=compiled
+else
+  KLOTHO_OUT_DIR="compiled-klotho/$KLOTHO_APP_NAME"
+fi
+export KLOTHO_OUT_DIR

--- a/ts-nextjs-typeorm/scripts/klotho/npm/klotho
+++ b/ts-nextjs-typeorm/scripts/klotho/npm/klotho
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ ! -d node_modules ]]; then
+  npm ci
+fi
+npx tsc
+strict_mode=''
+if [[ -n "${KLOTHO_STRICT-}" ]]; then
+  strict_mode='--strict'
+fi
+klotho . $strict_mode --app "$KLOTHO_APP_NAME" --outDir "$KLOTHO_OUT_DIR"
+npm --prefix "$KLOTHO_OUT_DIR" install

--- a/ts-nextjs-typeorm/scripts/klotho/npm/pulumi
+++ b/ts-nextjs-typeorm/scripts/klotho/npm/pulumi
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ -z "${PULUMI_CONFIG_PASSPHRASE+x}" && -z "${PULUMI_CONFIG_PASSPHRASE_FILE+x}" ]]; then
+  export PULUMI_CONFIG_PASSPHRASE=''
+fi
+
+pulumi -C "$KLOTHO_OUT_DIR" --stack "$KLOTHO_APP_NAME" "$@"

--- a/ts-nextjs-typeorm/src/next-app.ts
+++ b/ts-nextjs-typeorm/src/next-app.ts
@@ -8,6 +8,7 @@
  * @klotho::embed_assets {
  *   id = "public-assets"
  *   include = ["public/**", ".next/**"]
+ *   exclude = ["public/placeholder.md", ".next/placeholder.md"]
  * }
  */
 

--- a/ts-redis/package.json
+++ b/ts-redis/package.json
@@ -4,6 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "klotho": "scripts/klotho/npm/klotho",
+    "pulumi": "scripts/klotho/npm/pulumi",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/ts-redis/scripts/klotho/npm/_common.sh
+++ b/ts-redis/scripts/klotho/npm/_common.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")" # cd to where we are now
+cd ../../.. # get to repo root
+
+# Default the app name to the package name. If we have jq available on PATH, prefer that to "npm pkg" — it's
+# significantly faster.
+if &>/dev/null jq --version ;  then
+  default_app_name="$(cat package.json | jq -r .name)"
+else
+  default_app_name="$(npm pkg get name | sed -E 's/^"|"$//g')"
+fi
+if [[ -z "${KLOTHO_APP_NAME:-}" ]]; then
+  export KLOTHO_APP_NAME="$default_app_name"
+fi
+
+if [[ "$KLOTHO_APP_NAME" == "$default_app_name" ]]; then
+  KLOTHO_OUT_DIR=compiled
+else
+  KLOTHO_OUT_DIR="compiled-klotho/$KLOTHO_APP_NAME"
+fi
+export KLOTHO_OUT_DIR

--- a/ts-redis/scripts/klotho/npm/klotho
+++ b/ts-redis/scripts/klotho/npm/klotho
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ ! -d node_modules ]]; then
+  npm ci
+fi
+npx tsc
+strict_mode=''
+if [[ -n "${KLOTHO_STRICT-}" ]]; then
+  strict_mode='--strict'
+fi
+klotho . $strict_mode --app "$KLOTHO_APP_NAME" --outDir "$KLOTHO_OUT_DIR"
+npm --prefix "$KLOTHO_OUT_DIR" install

--- a/ts-redis/scripts/klotho/npm/pulumi
+++ b/ts-redis/scripts/klotho/npm/pulumi
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ -z "${PULUMI_CONFIG_PASSPHRASE+x}" && -z "${PULUMI_CONFIG_PASSPHRASE_FILE+x}" ]]; then
+  export PULUMI_CONFIG_PASSPHRASE=''
+fi
+
+pulumi -C "$KLOTHO_OUT_DIR" --stack "$KLOTHO_APP_NAME" "$@"

--- a/ts-schedule/package.json
+++ b/ts-schedule/package.json
@@ -4,6 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "klotho": "scripts/klotho/npm/klotho",
+    "pulumi": "scripts/klotho/npm/pulumi",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/ts-schedule/scripts/klotho/npm/_common.sh
+++ b/ts-schedule/scripts/klotho/npm/_common.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")" # cd to where we are now
+cd ../../.. # get to repo root
+
+# Default the app name to the package name. If we have jq available on PATH, prefer that to "npm pkg" — it's
+# significantly faster.
+if &>/dev/null jq --version ;  then
+  default_app_name="$(cat package.json | jq -r .name)"
+else
+  default_app_name="$(npm pkg get name | sed -E 's/^"|"$//g')"
+fi
+if [[ -z "${KLOTHO_APP_NAME:-}" ]]; then
+  export KLOTHO_APP_NAME="$default_app_name"
+fi
+
+if [[ "$KLOTHO_APP_NAME" == "$default_app_name" ]]; then
+  KLOTHO_OUT_DIR=compiled
+else
+  KLOTHO_OUT_DIR="compiled-klotho/$KLOTHO_APP_NAME"
+fi
+export KLOTHO_OUT_DIR

--- a/ts-schedule/scripts/klotho/npm/klotho
+++ b/ts-schedule/scripts/klotho/npm/klotho
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ ! -d node_modules ]]; then
+  npm ci
+fi
+npx tsc
+strict_mode=''
+if [[ -n "${KLOTHO_STRICT-}" ]]; then
+  strict_mode='--strict'
+fi
+klotho . $strict_mode --app "$KLOTHO_APP_NAME" --outDir "$KLOTHO_OUT_DIR"
+npm --prefix "$KLOTHO_OUT_DIR" install

--- a/ts-schedule/scripts/klotho/npm/pulumi
+++ b/ts-schedule/scripts/klotho/npm/pulumi
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ -z "${PULUMI_CONFIG_PASSPHRASE+x}" && -z "${PULUMI_CONFIG_PASSPHRASE_FILE+x}" ]]; then
+  export PULUMI_CONFIG_PASSPHRASE=''
+fi
+
+pulumi -C "$KLOTHO_OUT_DIR" --stack "$KLOTHO_APP_NAME" "$@"

--- a/ts-secrets/package.json
+++ b/ts-secrets/package.json
@@ -4,6 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "klotho": "scripts/klotho/npm/klotho",
+    "pulumi": "scripts/klotho/npm/pulumi",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/ts-secrets/scripts/klotho/npm/_common.sh
+++ b/ts-secrets/scripts/klotho/npm/_common.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")" # cd to where we are now
+cd ../../.. # get to repo root
+
+# Default the app name to the package name. If we have jq available on PATH, prefer that to "npm pkg" — it's
+# significantly faster.
+if &>/dev/null jq --version ;  then
+  default_app_name="$(cat package.json | jq -r .name)"
+else
+  default_app_name="$(npm pkg get name | sed -E 's/^"|"$//g')"
+fi
+if [[ -z "${KLOTHO_APP_NAME:-}" ]]; then
+  export KLOTHO_APP_NAME="$default_app_name"
+fi
+
+if [[ "$KLOTHO_APP_NAME" == "$default_app_name" ]]; then
+  KLOTHO_OUT_DIR=compiled
+else
+  KLOTHO_OUT_DIR="compiled-klotho/$KLOTHO_APP_NAME"
+fi
+export KLOTHO_OUT_DIR

--- a/ts-secrets/scripts/klotho/npm/klotho
+++ b/ts-secrets/scripts/klotho/npm/klotho
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ ! -d node_modules ]]; then
+  npm ci
+fi
+npx tsc
+strict_mode=''
+if [[ -n "${KLOTHO_STRICT-}" ]]; then
+  strict_mode='--strict'
+fi
+klotho . $strict_mode --app "$KLOTHO_APP_NAME" --outDir "$KLOTHO_OUT_DIR"
+npm --prefix "$KLOTHO_OUT_DIR" install

--- a/ts-secrets/scripts/klotho/npm/pulumi
+++ b/ts-secrets/scripts/klotho/npm/pulumi
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ -z "${PULUMI_CONFIG_PASSPHRASE+x}" && -z "${PULUMI_CONFIG_PASSPHRASE_FILE+x}" ]]; then
+  export PULUMI_CONFIG_PASSPHRASE=''
+fi
+
+pulumi -C "$KLOTHO_OUT_DIR" --stack "$KLOTHO_APP_NAME" "$@"

--- a/ts-sequelize/package.json
+++ b/ts-sequelize/package.json
@@ -4,6 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "klotho": "scripts/klotho/npm/klotho",
+    "pulumi": "scripts/klotho/npm/pulumi",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/ts-sequelize/scripts/klotho/npm/_common.sh
+++ b/ts-sequelize/scripts/klotho/npm/_common.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")" # cd to where we are now
+cd ../../.. # get to repo root
+
+# Default the app name to the package name. If we have jq available on PATH, prefer that to "npm pkg" — it's
+# significantly faster.
+if &>/dev/null jq --version ;  then
+  default_app_name="$(cat package.json | jq -r .name)"
+else
+  default_app_name="$(npm pkg get name | sed -E 's/^"|"$//g')"
+fi
+if [[ -z "${KLOTHO_APP_NAME:-}" ]]; then
+  export KLOTHO_APP_NAME="$default_app_name"
+fi
+
+if [[ "$KLOTHO_APP_NAME" == "$default_app_name" ]]; then
+  KLOTHO_OUT_DIR=compiled
+else
+  KLOTHO_OUT_DIR="compiled-klotho/$KLOTHO_APP_NAME"
+fi
+export KLOTHO_OUT_DIR

--- a/ts-sequelize/scripts/klotho/npm/klotho
+++ b/ts-sequelize/scripts/klotho/npm/klotho
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ ! -d node_modules ]]; then
+  npm ci
+fi
+npx tsc
+strict_mode=''
+if [[ -n "${KLOTHO_STRICT-}" ]]; then
+  strict_mode='--strict'
+fi
+klotho . $strict_mode --app "$KLOTHO_APP_NAME" --outDir "$KLOTHO_OUT_DIR"
+npm --prefix "$KLOTHO_OUT_DIR" install

--- a/ts-sequelize/scripts/klotho/npm/pulumi
+++ b/ts-sequelize/scripts/klotho/npm/pulumi
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ -z "${PULUMI_CONFIG_PASSPHRASE+x}" && -z "${PULUMI_CONFIG_PASSPHRASE_FILE+x}" ]]; then
+  export PULUMI_CONFIG_PASSPHRASE=''
+fi
+
+pulumi -C "$KLOTHO_OUT_DIR" --stack "$KLOTHO_APP_NAME" "$@"

--- a/ts-serverless-gateway/package.json
+++ b/ts-serverless-gateway/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "serverless-gw-sample-app",
   "scripts": {
     "klotho": "scripts/klotho/npm/klotho",
     "pulumi": "scripts/klotho/npm/pulumi"

--- a/ts-serverless-gateway/package.json
+++ b/ts-serverless-gateway/package.json
@@ -1,4 +1,8 @@
 {
+  "scripts": {
+    "klotho": "scripts/klotho/npm/klotho",
+    "pulumi": "scripts/klotho/npm/pulumi"
+  },
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.1"

--- a/ts-serverless-gateway/scripts/klotho/npm/_common.sh
+++ b/ts-serverless-gateway/scripts/klotho/npm/_common.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")" # cd to where we are now
+cd ../../.. # get to repo root
+
+# Default the app name to the package name. If we have jq available on PATH, prefer that to "npm pkg" — it's
+# significantly faster.
+if &>/dev/null jq --version ;  then
+  default_app_name="$(cat package.json | jq -r .name)"
+else
+  default_app_name="$(npm pkg get name | sed -E 's/^"|"$//g')"
+fi
+if [[ -z "${KLOTHO_APP_NAME:-}" ]]; then
+  export KLOTHO_APP_NAME="$default_app_name"
+fi
+
+if [[ "$KLOTHO_APP_NAME" == "$default_app_name" ]]; then
+  KLOTHO_OUT_DIR=compiled
+else
+  KLOTHO_OUT_DIR="compiled-klotho/$KLOTHO_APP_NAME"
+fi
+export KLOTHO_OUT_DIR

--- a/ts-serverless-gateway/scripts/klotho/npm/klotho
+++ b/ts-serverless-gateway/scripts/klotho/npm/klotho
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ ! -d node_modules ]]; then
+  npm ci
+fi
+npx tsc
+strict_mode=''
+if [[ -n "${KLOTHO_STRICT-}" ]]; then
+  strict_mode='--strict'
+fi
+klotho . $strict_mode --app "$KLOTHO_APP_NAME" --outDir "$KLOTHO_OUT_DIR"
+npm --prefix "$KLOTHO_OUT_DIR" install

--- a/ts-serverless-gateway/scripts/klotho/npm/pulumi
+++ b/ts-serverless-gateway/scripts/klotho/npm/pulumi
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ -z "${PULUMI_CONFIG_PASSPHRASE+x}" && -z "${PULUMI_CONFIG_PASSPHRASE_FILE+x}" ]]; then
+  export PULUMI_CONFIG_PASSPHRASE=''
+fi
+
+pulumi -C "$KLOTHO_OUT_DIR" --stack "$KLOTHO_APP_NAME" "$@"

--- a/ts-serverless-quickstart/package.json
+++ b/ts-serverless-quickstart/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "serverless-quickstart-sample-app",
   "scripts": {
     "klotho": "scripts/klotho/npm/klotho",
     "pulumi": "scripts/klotho/npm/pulumi"

--- a/ts-serverless-quickstart/package.json
+++ b/ts-serverless-quickstart/package.json
@@ -1,4 +1,8 @@
 {
+  "scripts": {
+    "klotho": "scripts/klotho/npm/klotho",
+    "pulumi": "scripts/klotho/npm/pulumi"
+  },
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.1"

--- a/ts-serverless-quickstart/scripts/klotho/npm/_common.sh
+++ b/ts-serverless-quickstart/scripts/klotho/npm/_common.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")" # cd to where we are now
+cd ../../.. # get to repo root
+
+# Default the app name to the package name. If we have jq available on PATH, prefer that to "npm pkg" — it's
+# significantly faster.
+if &>/dev/null jq --version ;  then
+  default_app_name="$(cat package.json | jq -r .name)"
+else
+  default_app_name="$(npm pkg get name | sed -E 's/^"|"$//g')"
+fi
+if [[ -z "${KLOTHO_APP_NAME:-}" ]]; then
+  export KLOTHO_APP_NAME="$default_app_name"
+fi
+
+if [[ "$KLOTHO_APP_NAME" == "$default_app_name" ]]; then
+  KLOTHO_OUT_DIR=compiled
+else
+  KLOTHO_OUT_DIR="compiled-klotho/$KLOTHO_APP_NAME"
+fi
+export KLOTHO_OUT_DIR

--- a/ts-serverless-quickstart/scripts/klotho/npm/klotho
+++ b/ts-serverless-quickstart/scripts/klotho/npm/klotho
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ ! -d node_modules ]]; then
+  npm ci
+fi
+npx tsc
+strict_mode=''
+if [[ -n "${KLOTHO_STRICT-}" ]]; then
+  strict_mode='--strict'
+fi
+klotho . $strict_mode --app "$KLOTHO_APP_NAME" --outDir "$KLOTHO_OUT_DIR"
+npm --prefix "$KLOTHO_OUT_DIR" install

--- a/ts-serverless-quickstart/scripts/klotho/npm/pulumi
+++ b/ts-serverless-quickstart/scripts/klotho/npm/pulumi
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ -z "${PULUMI_CONFIG_PASSPHRASE+x}" && -z "${PULUMI_CONFIG_PASSPHRASE_FILE+x}" ]]; then
+  export PULUMI_CONFIG_PASSPHRASE=''
+fi
+
+pulumi -C "$KLOTHO_OUT_DIR" --stack "$KLOTHO_APP_NAME" "$@"

--- a/ts-typeorm/package.json
+++ b/ts-typeorm/package.json
@@ -4,6 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "klotho": "scripts/klotho/npm/klotho",
+    "pulumi": "scripts/klotho/npm/pulumi",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/ts-typeorm/scripts/klotho/npm/_common.sh
+++ b/ts-typeorm/scripts/klotho/npm/_common.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")" # cd to where we are now
+cd ../../.. # get to repo root
+
+# Default the app name to the package name. If we have jq available on PATH, prefer that to "npm pkg" — it's
+# significantly faster.
+if &>/dev/null jq --version ;  then
+  default_app_name="$(cat package.json | jq -r .name)"
+else
+  default_app_name="$(npm pkg get name | sed -E 's/^"|"$//g')"
+fi
+if [[ -z "${KLOTHO_APP_NAME:-}" ]]; then
+  export KLOTHO_APP_NAME="$default_app_name"
+fi
+
+if [[ "$KLOTHO_APP_NAME" == "$default_app_name" ]]; then
+  KLOTHO_OUT_DIR=compiled
+else
+  KLOTHO_OUT_DIR="compiled-klotho/$KLOTHO_APP_NAME"
+fi
+export KLOTHO_OUT_DIR

--- a/ts-typeorm/scripts/klotho/npm/klotho
+++ b/ts-typeorm/scripts/klotho/npm/klotho
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ ! -d node_modules ]]; then
+  npm ci
+fi
+npx tsc
+strict_mode=''
+if [[ -n "${KLOTHO_STRICT-}" ]]; then
+  strict_mode='--strict'
+fi
+klotho . $strict_mode --app "$KLOTHO_APP_NAME" --outDir "$KLOTHO_OUT_DIR"
+npm --prefix "$KLOTHO_OUT_DIR" install

--- a/ts-typeorm/scripts/klotho/npm/pulumi
+++ b/ts-typeorm/scripts/klotho/npm/pulumi
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ -z "${PULUMI_CONFIG_PASSPHRASE+x}" && -z "${PULUMI_CONFIG_PASSPHRASE_FILE+x}" ]]; then
+  export PULUMI_CONFIG_PASSPHRASE=''
+fi
+
+pulumi -C "$KLOTHO_OUT_DIR" --stack "$KLOTHO_APP_NAME" "$@"


### PR DESCRIPTION
These are pretty much the same as the slackbot's, except with `--strict` turned off by default, and with the `--app` arg coming from the package.json. As part of that, I also added names to two projects that didn't have them.

Sorry for the large diff. These files are all identical (there are three files repeated over and over). I did that so that each dir is self-contained and can be cp'ed to serve as a template, but I can also conslidate them if people prefer.

This resolves #15.

To verify:

1. I ran `npm run klotho` and `npm run pulumi config set MY_CUSTOM_CONFIG` (just a dummy config name, to check that the pulumi config command worked):
   ```
   (
     set -e
     for d in */ ; do
       (
         cd "$d"
         pwd
         npm run klotho
         npm run pulumi -- stack select --create
         npm run pulumi config set MY_CUSTOM_CONFIG "$(date)"
       )
     done
   )
   ```
2. I did a quick grep to confirm that the configs got set:
   ```
   for d in */ ; do
   (
     cd "$d/compiled"
     grep MY_CUSTOM_CONFIG Pulumi.*
   )
   done
   ```
   This produced 16 lines of output, which is also how many sample apps we have.

3. I did `npm run pulumi up` on `ts-serverless-quickstart`, just to confirm that I could create the resources. I picked that one because it has the longest name of our sample apps.
