### PR TITLE
fix policy pack due to issues with awsx

### DIFF
--- a/ts-microservices/test/pulumi/index.ts
+++ b/ts-microservices/test/pulumi/index.ts
@@ -36,21 +36,6 @@ const ecsFargatePolicy: StackValidationPolicy = {
             reportViolation(`Expected one ecs task but found ${ecsTasks.length}`);
             return;
         }
-        const task = ecsTasks[0].asType(aws.ecs.TaskDefinition)!
-
-        const containerDefinitions = JSON.parse(task.containerDefinitions)
-        if (containerDefinitions.length !== 1) {
-            reportViolation(`Expected one container but found ${containerDefinitions.length}`);
-            return;
-        }
-        const container = containerDefinitions[0]
-
-        if (container.cpu !== 128) {
-            reportViolation(`Expected ecs task container definition '${container.name}' cpu to be '128' but found '${container.cpu}'`);
-        }
-        if (container.memory !== 256) {
-            reportViolation(`Expected ecs task container definition'${container.name}' memory to be '256' but found '${container.memory}'`);
-        }
     },
 }
 


### PR DESCRIPTION
awsx doesnt properly cast resources, so removing for now and when we switch to aws we can rewrite this. This is the same for eks stuff so have https://github.com/pulumi/pulumi-policy/issues/300 opened already but no traction