### PR TITLE
Adds python integration test support

### DIFF
--- a/.github/workflows/integtest.yaml
+++ b/.github/workflows/integtest.yaml
@@ -17,7 +17,13 @@ jobs:
         run: |
           dirs_with_tests="$(
             for d in $(find * -type d -maxdepth 0 || printf ''); do
-              jq &>/dev/null -e '.scripts."integ-test"' $d/package.json && echo "$d"
+              TESTABLE_APP=$(jq &>/dev/null -e '.scripts."integ-test"' $d/package.json && echo "$d")
+              if grep -s -q "^integ-test:" "${d}/Makefile"; then
+                TESTABLE_APP=$d
+              fi
+              if [[ -n "${TESTABLE_APP}" ]]; then
+                echo $TESTABLE_APP
+              fi
             done
             exit 0 # otherwise, will fail if the last dir failed the jq match
           )"
@@ -51,12 +57,28 @@ jobs:
           || '--cpus 1' }}
     steps:
       - uses: actions/checkout@v3
+
+      - name: get sample app language
+        id: get_language
+        run: echo language=$(echo "${{ matrix.app_to_test }}" | cut -d "-" -f 1) >> $GITHUB_OUTPUT
+
       - name: npm install
+        if: steps.get_language.outputs.language == 'ts'
         run: npm install
         working-directory: ${{ matrix.app_to_test }}
+
       - name: tsc
+        if: steps.get_language.outputs.language == 'ts'
         run: npx tsc
         working-directory: ${{ matrix.app_to_test }}
+
+      - name: pipenv install
+        if: steps.get_language.outputs.language == 'py'
+        working-directory: ${{ matrix.app_to_test }}
+        run: |
+          pip install pipenv
+          pipenv install -r requirements.txt
+
       - name: Test redis cluster
         if: matrix.app_to_test == 'ts-redis-cluster'
         uses: vishnudxb/redis-cluster@1.0.5
@@ -81,8 +103,10 @@ jobs:
         run: |
           if [[ -f test/integ_test_hooks/localhost-start.sh ]]; then
             cmd='bash test/integ_test_hooks/localhost-start.sh'
-          else
+          elif [[ "${{ steps.get_language.outputs.language }}" == "ts" ]]; then
             cmd='node dist/index.js'
+          else
+            cmd='make run'
           fi
           echo "Using start command: $cmd"
           $cmd >$RUNNER_TEMP/service.out 2>$RUNNER_TEMP/service.err &
@@ -90,7 +114,8 @@ jobs:
           echo "node-pid=$node_pid" >> $GITHUB_OUTPUT
         env:
           REDIS_PORT: ${{ job.services.redis.ports[6379] }}
-      - name: run tests
+      - name: run typescript tests
+        if: steps.get_language.outputs.language == 'ts'
         working-directory: ${{ matrix.app_to_test }}
         run: |
           # Note: We shouldn't need a global retry, but we do, due to async sets. See issues #44 and #33.
@@ -106,6 +131,24 @@ jobs:
             echo "::endgroup"
           done
           echo "::error title=npm run integ-test failed::Failed after $INTEG_TEST_ATTEMPTS attempts"
+          exit 1
+      - name: run python tests
+        if: steps.get_language.outputs.language == 'py'
+        working-directory: ${{ matrix.app_to_test }}
+        run: |
+          # Note: We shouldn't need a global retry, but we do, due to async sets. See issues #44 and #33.
+          INTEG_TEST_ATTEMPTS=3
+          for try_num in $(seq $INTEG_TEST_ATTEMPTS); do
+            echo "::group::Attempt $try_num"
+            if API_ENDPOINT=http://localhost:3000 make integ-test ; then
+              echo "::notice title=make integ-test succeeded::Succeeded on attempt $try_num"
+              echo "::endgroup"
+              exit
+            fi
+            sleep 5
+            echo "::endgroup"
+          done
+          echo "::error title=make integ-test failed::Failed after $INTEG_TEST_ATTEMPTS attempts"
           exit 1
       - name: service stop
         if: always() && steps.service-start.outputs.node-pid

--- a/.github/workflows/integtest.yaml
+++ b/.github/workflows/integtest.yaml
@@ -106,7 +106,7 @@ jobs:
           elif [[ "${{ steps.get_language.outputs.language }}" == "ts" ]]; then
             cmd='node dist/index.js'
           else
-            cmd='make run'
+            cmd='pipenv run make run'
           fi
           echo "Using start command: $cmd"
           $cmd >$RUNNER_TEMP/service.out 2>$RUNNER_TEMP/service.err &
@@ -140,7 +140,7 @@ jobs:
           INTEG_TEST_ATTEMPTS=3
           for try_num in $(seq $INTEG_TEST_ATTEMPTS); do
             echo "::group::Attempt $try_num"
-            if API_ENDPOINT=http://localhost:3000 make integ-test ; then
+            if API_ENDPOINT=http://localhost:3000 pipenv run make integ-test ; then
               echo "::notice title=make integ-test succeeded::Succeeded on attempt $try_num"
               echo "::endgroup"
               exit

--- a/.github/workflows/integtest.yaml
+++ b/.github/workflows/integtest.yaml
@@ -47,12 +47,12 @@ jobs:
         image: redis
         ports:
         - 6379/tcp
-        # Set health checks to wait until redis has started, but only for ts-redis.
+        # Set health checks to wait until redis has started, but only for ts-redis or py-redis.
         # ${{ condition && ifTrue || ifFalse }} works as a ternary operator.
         # We always need some valid docker option (even in the false case -- an empty string results in an error),
         # so if this isn't a redis service, just set CPUs to 1 as some arbitrary option.
         options: 
-          ${{ matrix.app_to_test == 'ts-redis' 
+          ${{ contains(fromJson('["ts-redis", "py-redis"]'), matrix.app_to_test)
           && '--health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5'
           || '--cpus 1' }}
     steps:
@@ -80,7 +80,7 @@ jobs:
           pipenv install -r requirements.txt
 
       - name: Test redis cluster
-        if: matrix.app_to_test == 'ts-redis-cluster'
+        if: contains(fromJson('["ts-redis-cluster", "py-redis-cluster"]'), matrix.app_to_test)
         uses: vishnudxb/redis-cluster@1.0.5
         with:
           master1-port: 8000
@@ -91,7 +91,7 @@ jobs:
           slave3-port: 8005
            # Running Test
       - name: ping redis cluster
-        if: matrix.app_to_test == 'ts-redis-cluster'
+        if: contains(fromJson('["ts-redis-cluster", "py-redis-cluster"]'), matrix.app_to_test)
         run: |
           sudo apt-get install -y redis-tools
           docker ps -a

--- a/.github/workflows/integtest.yaml
+++ b/.github/workflows/integtest.yaml
@@ -46,7 +46,7 @@ jobs:
       redis:
         image: redis
         ports:
-        - 6379/tcp
+        - 6379:6379/tcp
         # Set health checks to wait until redis has started, but only for ts-redis or py-redis.
         # ${{ condition && ifTrue || ifFalse }} works as a ternary operator.
         # We always need some valid docker option (even in the false case -- an empty string results in an error),

--- a/py-redis/README.md
+++ b/py-redis/README.md
@@ -19,11 +19,11 @@ make run
 
 Hit your endpoints
 ```sh
-curl -X POST http://localhost:3000/user -d '{"firstName": "john", "lastName": "doe"}' -H "Content-Type: application/json"
-# > success%
+curl -X POST http://localhost:3000/users -d '{"first_name": "john", "last_name": "doe"}' -H "Content-Type: application/json"
+# > Success
 
-curl http://localhost:3000/user/john
-# > doe%
+curl http://localhost:3000/users/john
+# > doe
 ```
 
 ## Compile and Deploy with Klotho
@@ -54,11 +54,11 @@ pulumi up -s py-redis
 
 ```sh
 # Add a user 
-curl -X POST  https://<...>.execute-api.us-east-1.amazonaws.com/stage/user -d '{"firstName": "john", "lastName": "doe"}' -H "Content-Type: application/json"
-# > success
+curl -X POST  https://<...>.execute-api.us-east-1.amazonaws.com/stage/users -d '{"first_name": "john", "last_name": "doe"}' -H "Content-Type: application/json"
+# > Success
 
 # Get a users last name
-curl https://<...>.execute-api.us-east-1.amazonaws.com/stage/user/john
+curl https://<...>.execute-api.us-east-1.amazonaws.com/stage/users/john
 # > doe
 ```
 


### PR DESCRIPTION
This PR adds support for running python integration tests with `make` for sample apps with a `py-` directory prefix.